### PR TITLE
Do not throw an exception when port is not open

### DIFF
--- a/33/portscanner_async.py
+++ b/33/portscanner_async.py
@@ -10,6 +10,8 @@ async def check_port(host: str, port: int, results: list):
         r, w = await asyncio.wait_for(future, timeout=timeout)
         results.append(port)
         w.close()
+    except OSError:  # do not throw an exception when port is not open
+        pass
     except asyncio.TimeoutError:
         pass # closed
 


### PR DESCRIPTION
... otherwise the program terminates without a result.


like so...
```
❯ python3.9 portscanner_async.py 
Traceback (most recent call last):
  File "/home/jugmac00/Projects/cpython-book-samples/33/portscanner_async.py", line 31, in <module>
    results = asyncio.run(scan(80, 100, host))
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/jugmac00/Projects/cpython-book-samples/33/portscanner_async.py", line 24, in scan
    await asyncio.gather(*tasks)
  File "/home/jugmac00/Projects/cpython-book-samples/33/portscanner_async.py", line 10, in check_port
    r, w = await asyncio.wait_for(future, timeout=timeout)
  File "/usr/lib/python3.9/asyncio/tasks.py", line 476, in wait_for
    return fut.result()
  File "/usr/lib/python3.9/asyncio/streams.py", line 52, in open_connection
    transport, _ = await loop.create_connection(
  File "/usr/lib/python3.9/asyncio/base_events.py", line 1064, in create_connection
    raise OSError('Multiple exceptions: {}'.format(
OSError: Multiple exceptions: [Errno 111] Connect call failed ('195.62.125.38', 81), [Errno 101] Network is unreachable
```